### PR TITLE
13 frontend ip addresses

### DIFF
--- a/caf_solution/landingzone.tf
+++ b/caf_solution/landingzone.tf
@@ -2,7 +2,7 @@ module "solution" {
   # source  = "aztfmod/caf/azurerm"
   # version = "5.7.10"
   # source = "git::https://github.com/aztfmod/terraform-azurerm-caf.git?ref=main"
-  source = "git::https://github.com/OuterSrc/terraform-azurerm-caf.git?ref=45-add-ars-module"
+  source = "git::https://github.com/OuterSrc/terraform-azurerm-caf.git?ref=v1.0.8"
 
   providers = {
     azurerm.vhub = azurerm.vhub

--- a/caf_solution/landingzone.tf
+++ b/caf_solution/landingzone.tf
@@ -2,7 +2,7 @@ module "solution" {
   # source  = "aztfmod/caf/azurerm"
   # version = "5.7.10"
   # source = "git::https://github.com/aztfmod/terraform-azurerm-caf.git?ref=main"
-  source = "git::https://github.com/OuterSrc/terraform-azurerm-caf.git?ref=43-frontend-ip-addresses"
+  source = "git::https://github.com/OuterSrc/terraform-azurerm-caf.git?ref=v1.0.7"
 
   providers = {
     azurerm.vhub = azurerm.vhub

--- a/caf_solution/landingzone.tf
+++ b/caf_solution/landingzone.tf
@@ -2,7 +2,7 @@ module "solution" {
   # source  = "aztfmod/caf/azurerm"
   # version = "5.7.10"
   # source = "git::https://github.com/aztfmod/terraform-azurerm-caf.git?ref=main"
-  source = "git::https://github.com/OuterSrc/terraform-azurerm-caf.git?ref=v1.0.7"
+  source = "git::https://github.com/OuterSrc/terraform-azurerm-caf.git?ref=45-add-ars-module"
 
   providers = {
     azurerm.vhub = azurerm.vhub

--- a/caf_solution/landingzone.tf
+++ b/caf_solution/landingzone.tf
@@ -2,7 +2,7 @@ module "solution" {
   # source  = "aztfmod/caf/azurerm"
   # version = "5.7.10"
   # source = "git::https://github.com/aztfmod/terraform-azurerm-caf.git?ref=main"
-  source = "git::https://github.com/OuterSrc/terraform-azurerm-caf.git?ref=v1.0.1"
+  source = "git::https://github.com/OuterSrc/terraform-azurerm-caf.git?ref=43-frontend-ip-addresses"
 
   providers = {
     azurerm.vhub = azurerm.vhub

--- a/caf_solution/local.networking.tf
+++ b/caf_solution/local.networking.tf
@@ -59,6 +59,7 @@ locals {
       public_ip_prefixes                                 = var.public_ip_prefixes
       relay_hybrid_connection                            = var.relay_hybrid_connection
       relay_namespace                                    = var.relay_namespace
+      route_servers                                      = var.route_servers
       route_tables                                       = var.route_tables
       traffic_manager_azure_endpoint                     = var.traffic_manager_azure_endpoint
       traffic_manager_external_endpoint                  = var.traffic_manager_external_endpoint

--- a/caf_solution/local.networking.tf
+++ b/caf_solution/local.networking.tf
@@ -60,6 +60,7 @@ locals {
       relay_hybrid_connection                            = var.relay_hybrid_connection
       relay_namespace                                    = var.relay_namespace
       route_servers                                      = var.route_servers
+      route_servers_bgp_connections                      = var.route_servers_bgp_connections
       route_tables                                       = var.route_tables
       traffic_manager_azure_endpoint                     = var.traffic_manager_azure_endpoint
       traffic_manager_external_endpoint                  = var.traffic_manager_external_endpoint

--- a/caf_solution/variables.networking.tf
+++ b/caf_solution/variables.networking.tf
@@ -127,6 +127,9 @@ variable "public_ip_addresses" {
 variable "route_servers" {
   default = {}
 }
+variable "route_servers_bgp_connections" {
+  default = {}
+}
 variable "route_tables" {
   default = {}
 }

--- a/caf_solution/variables.networking.tf
+++ b/caf_solution/variables.networking.tf
@@ -124,6 +124,9 @@ variable "private_dns_vnet_links" {
 variable "public_ip_addresses" {
   default = {}
 }
+variable "route_servers" {
+  default = {}
+}
 variable "route_tables" {
   default = {}
 }


### PR DESCRIPTION
bump aztfmod ref to v1.0.8
fixes Azure Load balancer tags and front end IP address limitation
Addes Azure Route Server capability

[Successful Pipeline run on Outersrc aztfmod v1.0.7](https://dev.azure.com/sercoazure/lz-sg-hub/_build/results?buildId=24944&view=logs&j=fc4b4ecc-4d80-5b68-35db-ecb09f019833&t=6408397a-c3e8-5dab-6da2-ab1b98f01b9b&l=281)

[Successful Pipeline run on Outersrc aztfmod v1.0.8](https://dev.azure.com/sercoazure/lz-sg-hub/_build/results?buildId=24998&view=logs&j=fc4b4ecc-4d80-5b68-35db-ecb09f019833&t=6408397a-c3e8-5dab-6da2-ab1b98f01b9b&l=334)